### PR TITLE
Deenurp issue27

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 * ``deenurp rdp_extract_sequences`` now updates old tax_ids instead of dropping them (issue: 27)
 * ``deenurp rdp_extract_sequences`` creates new column is_classified instead of dropping tax_ids of unclassified sequences (issue: 28)
 * function tax_of_genbank no longer returns None if string 'uncultured bacterium' is in the organism name (issue: 29)
+* expanding type strain designations to include more strings (issue: 16)
 
 0.1.1
 =====

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
  Changes for deenurp
 =====================
 
+0.1.2-HEAD
+==========
+
+* ``deenurp rdp_extract_sequences`` now updates old tax_ids instead of dropping them (issue: 27)
+* ``deenurp rdp_extract_sequences`` creates new column is_classified instead of dropping tax_ids of unclassified sequences (issue: 28)
+* function tax_of_genbank no longer returns None if string 'uncultured bacterium' is in the organism name (issue: 29)
+
 0.1.1
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,9 @@
 ==========
 
 * ``deenurp rdp_extract_sequences`` now updates old tax_ids instead of dropping them (issue: 27)
-* ``deenurp rdp_extract_sequences`` creates new column is_classified instead of dropping tax_ids of unclassified sequences (issue: 28)
+* ``deenurp rdp_extract_sequences`` creates new column taxid_classified instead of dropping tax_ids of unclassified sequences (issue: 28)
 * function tax_of_genbank no longer returns None if string 'uncultured bacterium' is in the organism name (issue: 29)
-* expanding type strain designations to include more strings (issue: 16)
+* expanding type strain designations to include more terms (issue: 16)
 
 0.1.1
 =====

--- a/deenurp/subcommands/rdp_sequence_filter.py
+++ b/deenurp/subcommands/rdp_sequence_filter.py
@@ -74,7 +74,7 @@ def action(a):
                     continue
                 accepted += 1
 
-                if info['is_classified'] == 'True':
+                if info['taxid_classified'] == 'True':
                     # named
                     fa_fp = named_fa_fp
                     w = named_writer

--- a/deenurp/subcommands/rdp_sequence_filter.py
+++ b/deenurp/subcommands/rdp_sequence_filter.py
@@ -1,4 +1,5 @@
-"""Splits RDP sequence file into named/unnamed sections, filters by length, percent ambiguity.
+"""Splits RDP sequence file into named/unnamed sections,
+filters by length, percent ambiguity.
 
 Assumes sequences in fasta_file and records in seqinfo_file are in the
 same order.
@@ -19,33 +20,39 @@ def count_ambiguous(seq):
 
 
 def build_parser(p):
-    p.add_argument('fasta_file', help="""sequence file""", type=file_opener('r'))
-    p.add_argument('seqinfo_file', help="""Sequence metadata""", type=file_opener('r'))
-    p.add_argument('--named-seqs', default='named.seqs.fasta', help='[default %(default)s]')
-    p.add_argument('--named-info', default='named.seq_info.fasta', help='[default %(default)s]')
-    p.add_argument('--unnamed-seqs', default='unnamed.seqs.fasta', help='[default %(default)s]')
-    p.add_argument('--unnamed-info', default='unnamed.seq_info.fasta',
-                   help='[default %(default)s]')
+    p.add_argument(
+        'fasta_file', help="""sequence file""", type=file_opener('r'))
+    p.add_argument(
+        'seqinfo_file', help="""Sequence metadata""", type=file_opener('r'))
+    p.add_argument(
+        '--named-seqs',
+        default='named.seqs.fasta', help='[default %(default)s]')
+    p.add_argument(
+        '--named-info',
+        default='named.seq_info.csv', help='[default %(default)s]')
+    p.add_argument(
+        '--unnamed-seqs',
+        default='unnamed.seqs.fasta', help='[default %(default)s]')
+    p.add_argument(
+        '--unnamed-info',
+        default='unnamed.seq_info.csv', help='[default %(default)s]')
 
     flt = p.add_argument_group('Filtering options')
     flt.add_argument('-a', '--prop-ambig-cutoff', default=0.01, type=float,
                      help="""Maximum proportion of characters in sequence which may be
-                     ambiguous [default: %(default).2f]""")
+                             ambiguous [default: %(default).2f]""")
     flt.add_argument('-l', '--min-length', type=int, help="""Minimum sequence
             length [default: %(default)d]""", default=1200)
 
 
 def action(a):
-    """
-    Run
-    """
     with a.fasta_file as fasta_fp, a.seqinfo_file as seqinfo_fp:
         sequences = Counter(SeqIO.parse(fasta_fp, 'fasta'))
         reader = csv.DictReader(seqinfo_fp)
         with open(a.named_seqs, 'w') as named_fa_fp, \
-            open(a.named_info, 'w') as named_si_fp, \
-            open(a.unnamed_seqs, 'w') as unnamed_fa_fp, \
-            open(a.unnamed_info, 'w') as unnamed_si_fp:
+                open(a.named_info, 'w') as named_si_fp, \
+                open(a.unnamed_seqs, 'w') as unnamed_fa_fp, \
+                open(a.unnamed_info, 'w') as unnamed_si_fp:
 
             unnamed_writer = csv.DictWriter(
                 unnamed_si_fp, reader.fieldnames, quoting=csv.QUOTE_NONNUMERIC)
@@ -57,7 +64,6 @@ def action(a):
             accepted = 0
             rejected = 0
             for sequence, info in itertools.izip(sequences, reader):
-            # for sequence, info in itertools.izip_longest(sequences, reader):
                 assert sequence.id == info['seqname']
 
                 # Check quality
@@ -68,7 +74,7 @@ def action(a):
                     continue
                 accepted += 1
 
-                if info['tax_id'] != '':
+                if info['is_classified'] == 'True':
                     # named
                     fa_fp = named_fa_fp
                     w = named_writer
@@ -78,5 +84,7 @@ def action(a):
                 w.writerow(info)
                 SeqIO.write([sequence], fa_fp, 'fasta')
 
-            logging.info("%d/%d passed (%.2f%%)", accepted, accepted+rejected,
-                         accepted/float(accepted+rejected) * 100.0)
+            logging.info("%d/%d passed (%.2f%%)",
+                         accepted,
+                         accepted + rejected,
+                         accepted / float(accepted + rejected) * 100.0)

--- a/deenurp/test/data/records.csv
+++ b/deenurp/test/data/records.csv
@@ -2,6 +2,6 @@ version,accession,id,name,description,gi,tax_id,date,source,keywords,organism
 NZ_JEYK02000005.1,NZ_JEYK02000005,NZ_JEYK02000005.1,NZ_JEYK02000005,"Acinetobacter baumannii 1592897 Ab1592897.contig.4_1, whole genome shotgun sequence.",727738441,1310696,01-DEC-2014,Acinetobacter baumannii 1592897,WGS;RefSeq,Acinetobacter baumannii 1592897
 NR_114178.1,NR_114178,NR_114178.1,NR_114178,"Granulosicoccus antarcticus strain NBRC 102684 16S ribosomal RNA gene, partial sequence.",631252980,1192854,03-FEB-2015,Granulosicoccus antarcticus IMCC3135,RefSeq,Granulosicoccus antarcticus IMCC3135
 JXVG01000028.1,JXVG01000028,JXVG01000028.1,JXVG01000028,"Vibrio parahaemolyticus strain 10-4245 contig28, whole genome shotgun sequence.",758719220,670,20-FEB-2015,Vibrio parahaemolyticus,WGS,Vibrio parahaemolyticus
-EF558678.1,EF558678,EF558678,S000855325,uncultured bacterium; BSLdp42.,,,01-JAN-1980,uncultured bacterium,,uncultured bacterium
+EF558678.1,EF558678,EF558678,S000855325,uncultured bacterium; BSLdp42.,,77133,01-JAN-1980,uncultured bacterium,,uncultured bacterium
 AY882670.1,AY882670,AY882670,S000631947,uncultured Acidimicrobium sp.; SK111.,,221084,01-JAN-1980,uncultured Acidimicrobium sp,,uncultured Acidimicrobium sp.
 EF682390.1,EF682390,EF682390,S000887598,uncultured prokaryote; BSLc270.,,198431,01-JAN-1980,uncultured prokaryote,,uncultured prokaryote

--- a/deenurp/util.py
+++ b/deenurp/util.py
@@ -257,9 +257,6 @@ def tax_of_genbank(gb):
     # Check for bad name
     try:
         source = next(i for i in gb.features if i.type == 'source')
-        organism = ''.join(source.qualifiers.get('organism', [])).lower()
-        if 'uncultured bacterium' in organism:
-            return
         taxon = next(i[6:] for i in source.qualifiers.get('db_xref', [])
                      if i.startswith('taxon:'))
         return taxon


### PR DESCRIPTION
* ``deenurp rdp_extract_sequences`` now updates old tax_ids instead of dropping them (issue: 27)
* ``deenurp rdp_extract_sequences`` creates new column is_classified instead of dropping tax_ids of unclassified sequences (issue: 28)
* function tax_of_genbank no longer returns None if string 'uncultured bacterium' is in the organism name (issue: 29)