### PR TITLE
hdbscan version bump, py3 fixes for 'deduplicate' subcommand 

### DIFF
--- a/deenurp/subcommands/deduplicate_sequences.py
+++ b/deenurp/subcommands/deduplicate_sequences.py
@@ -51,7 +51,7 @@ def action(args):
         seqhashes = dict()
         for record in util.Counter(SeqIO.parse(sequences_in, 'fasta')):
             seq = str(record.seq).replace('\n', '').upper()
-            seqhashes[record.name] = hashlib.sha1(seq).hexdigest()
+            seqhashes[record.name] = hashlib.sha1(seq.encode('utf-8')).hexdigest()
 
     seqhash = pandas.Series(data=seqhashes, name='seqhash')
     seqhash.index.name = 'seqname'

--- a/deenurp/util.py
+++ b/deenurp/util.py
@@ -48,20 +48,20 @@ class Counter(object):
         self.stream = stream
         self.report_every = report_every
         self.prefix = prefix
-        self.start = time.clock()
+        self.start = time.time()
         self.last = 0
 
     def _report(self):
         if self.stream:
             msg = '{0}{1:15d} [{2:10.2f}s]\r'
-            msg = msg.format(self.prefix, self.count, time.clock()-self.start)
+            msg = msg.format(self.prefix, self.count, time.time()-self.start)
             self.stream.write(msg)
 
     def __iter__(self):
         for i in self._it:
             yield i
             self.count += 1
-            now = time.clock()
+            now = time.time()
             if now - self.last > self.report_every:
                 self._report()
                 self.last = now

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ decorator==5.1.1
 DendroPy==4.5.2
 fastalite==0.3
 greenlet==1.1.2
-hdbscan==0.8.28
+hdbscan==0.8.33
 Jinja2==3.0.3
 joblib==1.1.0
 MarkupSafe==2.1.0


### PR DESCRIPTION
Closes #76 while also patching a couple of syntax issues in the [deduplicate_sequences.py](https://github.com/fhcrc/deenurp/pull/77/files#diff-e6b094ef95358f784f098f392eea554d30b990f6cda68424225c962b4f4ba792) subcommand, presumably overlooked in the 2to3 conversion long ago.